### PR TITLE
feat: enable disable form options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ To use the default template for the editable footer, add `src/addons/volto-edita
 
 ### Configuration
 
-By default, column configuration shows all available options.
-If not needed, you could remove unused options in config:
+By default, column configuration doesn't show all available options.
+If not needed, you could add options in config:
 
 ```json
 config.settings["volto-editablefooter"] = {
-  "options": { "socials": true, "newsletterSubscribe": true },
+  "options": { "socials": false, "newsletterSubscribe": false },
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ By default, column configuration shows all available options.
 If not needed, you could remove unused options in config:
 
 ```json
- config.settings["volto-editablefooter"] = {
+config.settings["volto-editablefooter"] = {
   "options": { "socials": true, "newsletterSubscribe": true },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ To use the default template for the editable footer, add `src/addons/volto-edita
   ]
 ```
 
+### Configuration
+
+By default, column configuration shows all available options.
+If not needed, you could remove unused options in config:
+
+```json
+ config.settings["volto-editablefooter"] = {
+    "options": { "socials": true, "newsletterSubscribe": true },
+  };
+```
+
 ## Translations
 
 This product has been translated into:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ config.settings["volto-editablefooter"] = {
 };
 ```
 
+### Upgrades
+
+#### Upgrade to 4.x.x
+If you are upgrading your addon to a 4.x.x version, add this addon configuration in your config:
+
+```json
+config.settings["volto-editablefooter"] = {
+  "options": { "socials": true, "newsletterSubscribe": true },
+};
+```
+
 ## Translations
 
 This product has been translated into:

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ If not needed, you could remove unused options in config:
 
 ```json
  config.settings["volto-editablefooter"] = {
-    "options": { "socials": true, "newsletterSubscribe": true },
-  };
+  "options": { "socials": true, "newsletterSubscribe": true },
+};
 ```
 
 ## Translations

--- a/src/index.js
+++ b/src/index.js
@@ -43,5 +43,8 @@ export default (config) => {
     },
   ];
 
+  config.settings['volto-editablefooter'] = {
+    options: { socials: true, newsletterSubscribe: true },
+  };
   return config;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ export default (config) => {
   ];
 
   config.settings['volto-editablefooter'] = {
-    options: { socials: true, newsletterSubscribe: true },
+    options: { socials: false, newsletterSubscribe: false },
   };
   return config;
 };

--- a/src/widget/FooterConfigurationForm.jsx
+++ b/src/widget/FooterConfigurationForm.jsx
@@ -10,7 +10,6 @@ import {
 import { Portal } from 'react-portal';
 import config from '@plone/volto/registry';
 
-
 const messages = defineMessages({
   title: {
     id: 'editablefooter-title',
@@ -106,22 +105,28 @@ const FooterConfigurationForm = ({
         value={!!footerColumn.visible}
         onChange={(id, value) => onChangeFormData('visible', value)}
       />
-      <CheckboxWidget
-        id={`${id}-showSocial`}
-        title={intl.formatMessage(messages.showSocial)}
-        description=""
-        defaultValue={true}
-        value={!!footerColumn.showSocial}
-        onChange={(id, value) => onChangeFormData('showSocial', value)}
-      />
-      <CheckboxWidget
-        id={`${id}-newsletterSubscribe`}
-        title={intl.formatMessage(messages.newsletterSubscribe)}
-        description=""
-        defaultValue={true}
-        value={!!footerColumn.newsletterSubscribe}
-        onChange={(id, value) => onChangeFormData('newsletterSubscribe', value)}
-      />
+      {config.settings['volto-editablefooter'].options.socials && (
+        <CheckboxWidget
+          id={`${id}-showSocial`}
+          title={intl.formatMessage(messages.showSocial)}
+          description=""
+          defaultValue={true}
+          value={!!footerColumn.showSocial}
+          onChange={(id, value) => onChangeFormData('showSocial', value)}
+        />
+      )}
+      {config.settings['volto-editablefooter'].options.newsletterSubscribe && (
+        <CheckboxWidget
+          id={`${id}-newsletterSubscribe`}
+          title={intl.formatMessage(messages.newsletterSubscribe)}
+          description=""
+          defaultValue={true}
+          value={!!footerColumn.newsletterSubscribe}
+          onChange={(id, value) =>
+            onChangeFormData('newsletterSubscribe', value)
+          }
+        />
+      )}
       <ObjectBrowserWidget
         id={`${id}-titleLink`}
         title={intl.formatMessage(messages.titleLink)}


### PR DESCRIPTION
Is now possible to show or not some options in the column configuration from config:

```
config.settings["volto-editablefooter"] = {
    "options": { "socials": true, "newsletterSubscribe": true },
  };
```