### PR TITLE
fix: a11y for columns and edit content

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr "Aggiungi una colonna del footer"
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr "Colonna"
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr "Modifica il contenuto della colonna"
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr "Selezione delle colonne"
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr "Rimuovi"
@@ -70,6 +85,11 @@ msgstr "Sposta prima"
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
 msgstr "Mostra il form di iscrizione alla newsletter"
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
+msgstr "senza titolo"
 
 #: widget/FooterConfigurationWidget
 # defaultMessage: Root path

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr "Coluna"
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr "Modificar o conteúdo da coluna"
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr "Seleção das colunas"
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -70,6 +85,11 @@ msgstr ""
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
 msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
+msgstr "sem título"
 
 #: widget/FooterConfigurationWidget
 # defaultMessage: Root path

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -22,6 +22,21 @@ msgid "editablefooter-addfootercolumn"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
 # defaultMessage: Delete
 msgid "editablefooter-delete-button"
 msgstr ""
@@ -69,6 +84,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-10-23T14:58:40.747Z\n"
+"POT-Creation-Date: 2023-11-14T16:08:48.472Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -21,6 +21,21 @@ msgstr ""
 #: widget/FooterConfigurationWidget
 # defaultMessage: Add footer column
 msgid "editablefooter-addfootercolumn"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column
+msgid "editablefooter-column"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Edit column content
+msgid "editablefooter-column-content"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: Column selection
+msgid "editablefooter-column-selection"
 msgstr ""
 
 #: widget/FooterConfigurationWidget
@@ -71,6 +86,11 @@ msgstr ""
 #: widget/FooterConfigurationForm
 # defaultMessage: Show newsletter subscribe form
 msgid "editablefooter-newsletterSubscribe"
+msgstr ""
+
+#: widget/FooterConfigurationWidget
+# defaultMessage: without title
+msgid "editablefooter-no-title"
 msgstr ""
 
 #: widget/FooterConfigurationWidget

--- a/src/widget/FooterConfigurationWidget.jsx
+++ b/src/widget/FooterConfigurationWidget.jsx
@@ -345,7 +345,6 @@ const FooterConfigurationWidget = ({
                                     title={intl.formatMessage(
                                       messages.moveMenuItemUp,
                                     )}
-                                    // aria-describedby={`footer-item-${idx}`}
                                     onClick={(e) =>
                                       moveMenuItem(e, activeFooter, idx, 'up')
                                     }
@@ -362,7 +361,6 @@ const FooterConfigurationWidget = ({
                                     title={intl.formatMessage(
                                       messages.moveMenuItemDown,
                                     )}
-                                    // aria-describedby={`footer-item-${idx}`}
                                     onClick={(e) =>
                                       moveMenuItem(e, activeFooter, idx, 'down')
                                     }

--- a/src/widget/FooterConfigurationWidget.jsx
+++ b/src/widget/FooterConfigurationWidget.jsx
@@ -56,6 +56,23 @@ const messages = defineMessages({
     id: 'editablefooter-emptyActiveFooterColumn',
     defaultMessage: 'Select or add a footer column',
   },
+
+  column: {
+    id: 'editablefooter-column',
+    defaultMessage: 'Column',
+  },
+  no_title: {
+    id: 'editablefooter-no-title',
+    defaultMessage: 'without title',
+  },
+  column_selection: {
+    id: 'editablefooter-column-selection',
+    defaultMessage: 'Column selection',
+  },
+  column_content: {
+    id: 'editablefooter-column-content',
+    defaultMessage: 'Edit column content',
+  },
 });
 
 const defaultMenuItem = (title) => ({
@@ -215,6 +232,7 @@ const FooterConfigurationWidget = ({
                     active={false}
                     name={intl.formatMessage(messages.addFooterPath)}
                     onClick={addFooterPath}
+                    aria-label={intl.formatMessage(messages.addFooterPath)}
                   >
                     <Icon name="plus" />
                   </Menu.Item>
@@ -279,6 +297,10 @@ const FooterConfigurationWidget = ({
                           vertical
                           tabular
                           className="footer-items-menu"
+                          role="region"
+                          aria-label={intl.formatMessage(
+                            messages.column_selection,
+                          )}
                         >
                           {footerConfiguration[activeFooter].items?.map(
                             (footerColumn, idx) => (
@@ -287,8 +309,35 @@ const FooterConfigurationWidget = ({
                                 name={footerColumn.title}
                                 active={activeFooterColumn === idx}
                                 onClick={() => setActiveFooterColumn(idx)}
+                                aria-controls={'footerConfigContent'}
+                                as="button"
+                                aria-expanded={activeFooterColumn === idx}
+                                aria-label={
+                                  intl.formatMessage(messages.column) +
+                                  ' ' +
+                                  (idx + 1) +
+                                  ' ' +
+                                  (footerColumn.title ??
+                                    intl.formatMessage(messages.no_title))
+                                }
                               >
-                                <Button.Group vertical className="move-buttons">
+                                <Button.Group
+                                  vertical
+                                  className="move-buttons"
+                                  key={`footer-item-${idx}`}
+                                  id={`footer-item-${idx}`}
+                                  name={footerColumn.title}
+                                  active={activeFooterColumn === idx}
+                                  onClick={() => setActiveFooterColumn(idx)}
+                                  aria-label={
+                                    intl.formatMessage(messages.column) +
+                                    ' ' +
+                                    (idx + 1) +
+                                    ' ' +
+                                    (footerColumn.title ??
+                                      intl.formatMessage(messages.no_title))
+                                  }
+                                >
                                   <Button
                                     disabled={idx === 0}
                                     size="tiny"
@@ -296,6 +345,7 @@ const FooterConfigurationWidget = ({
                                     title={intl.formatMessage(
                                       messages.moveMenuItemUp,
                                     )}
+                                    // aria-describedby={`footer-item-${idx}`}
                                     onClick={(e) =>
                                       moveMenuItem(e, activeFooter, idx, 'up')
                                     }
@@ -312,6 +362,7 @@ const FooterConfigurationWidget = ({
                                     title={intl.formatMessage(
                                       messages.moveMenuItemDown,
                                     )}
+                                    // aria-describedby={`footer-item-${idx}`}
                                     onClick={(e) =>
                                       moveMenuItem(e, activeFooter, idx, 'down')
                                     }
@@ -322,7 +373,11 @@ const FooterConfigurationWidget = ({
                             ),
                           )}
                           <Menu.Item
+                            as={'button'}
                             name={intl.formatMessage(messages.addFooterColumn)}
+                            aria-label={intl.formatMessage(
+                              messages.addFooterColumn,
+                            )}
                             onClick={(e) => addFooterColumn(e, activeFooter)}
                           >
                             <Icon name="plus" />
@@ -333,32 +388,41 @@ const FooterConfigurationWidget = ({
                         {activeFooterColumn > -1 &&
                         activeFooterColumn <
                           footerConfiguration[activeFooter].items?.length ? (
-                          <FooterConfigurationForm
-                            id={
-                              footerConfiguration[activeFooter].items[
-                                activeFooterColumn
-                              ].id
-                            }
-                            footerColumn={
-                              footerConfiguration[activeFooter].items[
-                                activeFooterColumn
-                              ]
-                            }
-                            onChange={(column) =>
-                              onChangeFooterColumn(
-                                activeFooter,
-                                activeFooterColumn,
-                                column,
-                              )
-                            }
-                            deleteFooterColumn={(e) =>
-                              deleteFooterColumn(
-                                e,
-                                activeFooter,
-                                activeFooterColumn,
-                              )
-                            }
-                          />
+                          <div
+                            id="footerConfigContent"
+                            role="region"
+                            aria-label={intl.formatMessage(
+                              messages.column_content,
+                            )}
+                          >
+                            <FooterConfigurationForm
+                              arial-label="text"
+                              id={
+                                footerConfiguration[activeFooter].items[
+                                  activeFooterColumn
+                                ].id
+                              }
+                              footerColumn={
+                                footerConfiguration[activeFooter].items[
+                                  activeFooterColumn
+                                ]
+                              }
+                              onChange={(column) =>
+                                onChangeFooterColumn(
+                                  activeFooter,
+                                  activeFooterColumn,
+                                  column,
+                                )
+                              }
+                              deleteFooterColumn={(e) =>
+                                deleteFooterColumn(
+                                  e,
+                                  activeFooter,
+                                  activeFooterColumn,
+                                )
+                              }
+                            />
+                          </div>
                         ) : (
                           <span>
                             {intl.formatMessage(

--- a/src/widget/footer_configuration.css
+++ b/src/widget/footer_configuration.css
@@ -49,11 +49,19 @@
   justify-content: space-between;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
+  margin: 0px 0px 0px 1px !important;
+  width: 100%;
+  cursor: pointer;
+}
+.footer-configuration-widget .ui.menu.footer-items-menu .item:hover,
+.cms-ui .footer-configuration-widget .ui.menu.footer-items-menu .item:hover {
+  background-color: #fafafa !important;
 }
 
 .footer-configuration-widget .ui.menu.footer-items-menu .item span,
 .cms-ui .footer-configuration-widget .ui.menu.footer-items-menu .item span {
   margin-left: 0.5rem;
+  text-align: start;
 }
 
 .footer-configuration-widget .ui.menu.footer-items-menu .item button.ui.button,


### PR DESCRIPTION
- 2 new regions created for landmarks ("Column selection" and "Edit column content")
- The tabs now contain buttons instead of regular links
- All buttons with a proper label inside the tabs
- The "+" now is a button with a proper label

Note: 
The aria-labels for Menu.Item and Button.Group are quite different because of a condition, with or without title. It's basically 2 default messages together if the title isn't set. I couldn't use props as I would like, using only one id because the condition doesn't allow me to translate the second part of the sentence.

`aria-label={intl.formatMessage(messages.column) + ' ' + (idx + 1) + ' ' + (footerColumn.title ?? intl.formatMessage(messages.no_title))}` 