### PR TITLE
fix: FooterTop hooks-order instability

### DIFF
--- a/src/components/FooterTop.jsx
+++ b/src/components/FooterTop.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
@@ -10,8 +10,6 @@ import { RichTextRender } from 'volto-blocks-widget';
 const FooterTop = () => {
   const location = useLocation();
   const dispatch = useDispatch();
-
-  const [footerTopData, setFooterTopData] = useState([]);
 
   const confLoading = useSelector(
     (state) => state.editableFooterColumns.loadingResults,
@@ -28,23 +26,14 @@ const FooterTop = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    //filter rootpaths
-    const FooterConfig = getConfigByPath(
-      footerConfiguration,
-      location?.pathname?.length ? location.pathname : '/',
-    );
+  const footerTopData = getConfigByPath(
+    footerConfiguration,
+    location?.pathname?.length ? location.pathname : '/',
+  )?.footerTop;
 
-    setFooterTopData(FooterConfig.footerTop);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [footerConfiguration, location]);
-
-  return footerTopData
-    ? RichTextRender({
-        data: footerTopData,
-        add_class: 'footerTop',
-      })
-    : null;
+  return footerTopData ? (
+    <RichTextRender data={footerTopData} add_class="footerTop" />
+  ) : null;
 };
 
 export default FooterTop;


### PR DESCRIPTION
FooterTop called RichTextRender({...}) as a plain function instead of rendering it as JSX. That merges RichTextRender's own hooks (whose count scales with the number of footerTop blocks) directly into FooterTop's hook list, so the hook count changes once the async footer config finishes loading, triggering "React has detected a change in the order of Hooks".

Also drop the useState/second useEffect pair that just mirrored getConfigByPath(footerConfiguration, location) into local state: since getConfigByPath is a pure, cheap lookup, it can be computed directly during render instead, which also removes an extra render pass before the correct footerTop content shows up.