### PR TITLE
fix: allow Enter key inside footerTop blocks editor

### DIFF
--- a/src/widget/FooterConfigurationForm.jsx
+++ b/src/widget/FooterConfigurationForm.jsx
@@ -62,12 +62,15 @@ const FooterConfigurationForm = ({
     };
 
     // global handler to stop Enter from submitting inputs
-    // exception: slate_wysiwyg_box (to add slate text)
+    // exception: slate_wysiwyg_box (to add slate text) and blocks-widget
+    // (footerTop blocks editor), where Enter never triggers a submit
     const handleEnter = (e) => {
       if (e.key === 'Enter') {
         const targetForm = e.target.closest('form.ui.form');
         if (targetForm) {
-          const inBlocks = e.target.closest('.slate_wysiwyg_box');
+          const inBlocks = e.target.closest(
+            '.slate_wysiwyg_box, .blocks-widget',
+          );
           if (inBlocks) {
             // allow enter to add blocks (React/Volto create new blocks)
             return;


### PR DESCRIPTION
The global Enter handler in FooterConfigurationForm blocked keydown events for everything outside .slate_wysiwyg_box to prevent form submits. This also killed Enter inside the footerTop BlocksWidget (e.g. text blocks inside a grid), making it impossible to add line breaks or split list items. Extend the exception to .blocks-widget, where Enter can never trigger a submit.